### PR TITLE
Fix the demeaning within unit

### DIFF
--- a/ado/did2s.ado
+++ b/ado/did2s.ado
@@ -42,11 +42,10 @@ program define did2s, eclass
     
     * Manually demean all the first_stage vars by id (when treat == 0)
     if ("`unit'" != "") {
-      tempvar mean mean0
+      tempvar mean
       foreach var of varlist `full_first_stage' `varlist' {
-        cap drop `mean' `mean0'
-        quietly by `unit': egen `mean0' = mean(`var') if (`touse' == 1) & (`treatment' == 0)
-        quietly by `unit': egen `mean' = median(`mean0') if `touse'
+        cap drop `mean'
+        quietly egen double `mean' = mean(cond(`touse' & `treatment' == 0, `var', .)), by(`unit')
         quietly replace `var' = `var' - `mean'
       }
     }

--- a/ado/did2s.ado
+++ b/ado/did2s.ado
@@ -41,12 +41,12 @@ program define did2s, eclass
     local full_first_stage "`r(varlist)' `ones'"
     
     * Manually demean all the first_stage vars by id (when treat == 0)
-    if("`unit'" != "") {
+    if ("`unit'" != "") {
       tempvar mean mean0
       foreach var of varlist `full_first_stage' `varlist' {
         cap drop `mean' `mean0'
-        quietly by `unit': egen `mean0' = mean(`var') if `treatment' == 0
-        quietly by `unit': egen `mean' = median(`mean0')
+        quietly by `unit': egen `mean0' = mean(`var') if (`touse' == 1) & (`treatment' == 0)
+        quietly by `unit': egen `mean' = median(`mean0') if `touse'
         quietly replace `var' = `var' - `mean'
       }
     }


### PR DESCRIPTION
It looks like the code for demeaning the variables within unit was ignoring the `if` and `in` conditions specified by the user. Here is what I mean:

```stata
use https://github.com/kylebutts/did2s_stata/raw/main/data/df_hom.dta, clear

sort unit year
did2s dep_var if year >= 1995, first_stage(i.year) unit(unit) ///
    second_stage(i.treat) treatment(treat) cluster(state)

// This should have no effect because data before 1995 should not be used 
replace dep_var = 0 if year < 1995
did2s dep_var if year >= 1995, first_stage(i.year) unit(unit) ///
    second_stage(i.treat) treatment(treat) cluster(state)
```

The first produces an estimate of 2.011458 and the second produces an estimate of 2.76515. The estimate should be 1.991944 (this is what would happen if we dropped rows from before 1995). Basically, everything was being used when calculating the untreated unit means regardless of the `if` and `in` conditions.

Commit e1eb2519 fixes this and commit 5d993816 makes slight performance improvements and removes the requirement that the data be sorted by `unit` when using that option.